### PR TITLE
Upgrade Jinja2 to 2.10.1

### DIFF
--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -1,5 +1,5 @@
 MySQL-python==1.2.3c1
-Jinja2==2.5.5
+Jinja2>=2.10.1 
 
 # For PDF generation via ReportLab
 PIL==1.1.7


### PR DESCRIPTION
Mitigate [CVE-2016-10745](https://github.com/advisories/GHSA-hj2j-77xm-mc5v) and [CVE-2019-10906](https://github.com/advisories/GHSA-462w-v97r-4m45). `str.format_map` and `str.format` allow a sandbox escape.

Though spark doesn't use `str.format_map`, it does use `str.format`.

I can't tell if a user can control the payload in this cases which could allow for exploitation
* https://github.com/mozilla/spark/blob/071d6da19076ee047530220223d7beab3d31abab/apps/desktop/views.py#L144